### PR TITLE
Redeploy gh action

### DIFF
--- a/.github/workflows/redeploy.yaml
+++ b/.github/workflows/redeploy.yaml
@@ -37,9 +37,7 @@ jobs:
       - name: "Git pull master and launch redeploy.sh"
         run: |
           gcloud compute ssh --zone ${TARGET_ZONE} ${TARGET_USER}@${TARGET_MACHINE} -- \
-            cd /var/checkouts/ontotools-docker && \
-            git pull && \
-            time ( sudo ./redeploy.sh )
+            /var/checkouts/ontotools-docker/pull_and_redeploy.sh
 
       - name: "Size down OLS machine for serving"
         if: always() # run even if the prior tasks fail, as we don't want it stuck as a large instance

--- a/.github/workflows/redeploy.yaml
+++ b/.github/workflows/redeploy.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
         with:
+        
           version: ">= 447.0.0"
 
       - name: "Size up OLS machine for pipeline run"
@@ -36,7 +37,7 @@ jobs:
 
       - name: "Git pull master and launch redeploy.sh"
         run: |
-          gcloud compute ssh --zone ${TARGET_ZONE} ${TARGET_USER}@${TARGET_MACHINE} -- \
+          gcloud compute ssh --zone ${TARGET_ZONE} ${TARGET_USER}@${TARGET_MACHINE} -- -t \
             /var/checkouts/ontotools-docker/pull_and_redeploy.sh
 
       - name: "Size down OLS machine for serving"

--- a/.github/workflows/redeploy.yaml
+++ b/.github/workflows/redeploy.yaml
@@ -1,0 +1,47 @@
+name: Redeploy OLS pipeline
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - redeploy-gh-action
+
+env:
+  TARGET_MACHINE: "ontotools-stack"
+  TARGET_ZONE: "${TARGET_ZONE}"
+  MACHINE_TYPE_BUILDING: "e2-highmem-4"
+  MACHINE_TYPE_SERVING: "e2-medium"
+
+jobs:
+  update-gcp-services:
+    runs-on: ubuntu-latest
+    steps:
+      - id: "auth"
+        uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+        with:
+          version: ">= 447.0.0"
+
+      - name: "Size up OLS machine for pipeline run"
+        run: |
+          gcloud compute instances stop --zone ${TARGET_ZONE} ${TARGET_MACHINE} && \
+          gcloud compute instances set-machine-type --zone ${TARGET_ZONE} ${TARGET_MACHINE} --machine-type=${MACHINE_TYPE_BUILDING}
+          gcloud compute instances start --zone ${TARGET_ZONE} ${TARGET_MACHINE}
+
+      - name: "Git pull master and launch redeploy.sh"
+        run: |
+          gcloud compute ssh --zone ${TARGET_ZONE} ${TARGET_MACHINE} -- \
+            cd /var/checkouts/ontotools-docker && \
+            sudo redeploy.sh
+
+      - name: "Size down OLS machine for serving"
+        if: always() # run even if the prior tasks fail, as we don't want it stuck as a large instance
+        run: |
+          gcloud compute instances stop --zone ${TARGET_ZONE} ${TARGET_MACHINE} && \
+          gcloud compute instances set-machine-type --zone ${TARGET_ZONE} ${TARGET_MACHINE} --machine-type=${MACHINE_TYPE_SERVING}
+          gcloud compute instances start --zone ${TARGET_ZONE} ${TARGET_MACHINE}

--- a/.github/workflows/redeploy.yaml
+++ b/.github/workflows/redeploy.yaml
@@ -10,6 +10,7 @@ on:
 env:
   TARGET_MACHINE: "ontotools-stack"
   TARGET_ZONE: "us-central1-a"
+  TARGET_USER: "ols_deployer"
   MACHINE_TYPE_BUILDING: "e2-highmem-4"
   MACHINE_TYPE_SERVING: "e2-medium"
 
@@ -35,9 +36,10 @@ jobs:
 
       - name: "Git pull master and launch redeploy.sh"
         run: |
-          gcloud compute ssh --zone ${TARGET_ZONE} ${TARGET_MACHINE} -- \
+          gcloud compute ssh --zone ${TARGET_ZONE} ${TARGET_USER}@${TARGET_MACHINE} -- \
             cd /var/checkouts/ontotools-docker && \
-            sudo redeploy.sh
+            git pull && \
+            time ( sudo ./redeploy.sh )
 
       - name: "Size down OLS machine for serving"
         if: always() # run even if the prior tasks fail, as we don't want it stuck as a large instance

--- a/.github/workflows/redeploy.yaml
+++ b/.github/workflows/redeploy.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   TARGET_MACHINE: "ontotools-stack"
-  TARGET_ZONE: "${TARGET_ZONE}"
+  TARGET_ZONE: "us-central1-a"
   MACHINE_TYPE_BUILDING: "e2-highmem-4"
   MACHINE_TYPE_SERVING: "e2-medium"
 

--- a/pull_and_redeploy.sh
+++ b/pull_and_redeploy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# this script first performs a git pull in the script's folder, then
+# wraps redeploy.sh, redirecting stdout and stderr to
+# deploy_$( date )_stdout.log and deploy_$( date )_stderr.log, respectively.
+# (we write the output to those logfiles mostly because it's massive, but
+# also for forensic purposes if something should go wrong.)
+
+# the script will typically be invoked from a github action
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+CUR_DATE=$( date +%Y%m%d_%H%M%S )
+
+STDOUT_LOGFILE="${SCRIPT_DIR}/deploy_${CUR_DATE}_stdout.log"
+STDERR_LOGFILE="${SCRIPT_DIR}/deploy_${CUR_DATE}_stderr.log"
+
+cd "${SCRIPT_DIR}" && \
+git pull && \
+time (
+    echo "Performing redeploy; writing results to: "
+    echo " - stdout: ${STDOUT_LOGFILE}"
+    echo " - stderr: ${STDERR_LOGFILE}"
+
+    sudo ./redeploy.sh > ${STDOUT_LOGFILE} 2> ${STDERR_LOGFILE}
+
+    echo "...done!"
+)


### PR DESCRIPTION
This PR introduces a GitHub workflow in [.github/workflows/redeploy.yaml](https://github.com/monarch-initiative/ontotools-docker/compare/master...monarch-initiative:ontotools-docker:redeploy-gh-action#diff-c87a00c545962b2ba8908fe23f5068180e48113a75591661e785313257e0ad46) that, when triggered, does the following:

1. Uses the service account credentials stored in the repo secret `JSON_GCLOUD_SERVICE_ACCOUNT_JSON` to authenticate to the service account `ols-deployer@monarch-initiative.iam.gserviceaccount.com`.
2. Stops the VM `ontotools-stack`, resizes it to an `e2-highmem-4` (configurations with less memory have been found to fail), then starts it again.
3. SSH's into the VM as the user `ols_deployer` and runs the script `pull_and_redeploy.sh`. That script first does a git pull in the folder `/var/checkouts/ontotools-docker/` on whatever branch is currently checked out (ideally `main`), then runs the `redeploy.sh` script. The most recent runs have taken ~40 minutes, but this will vary depending on the input ontologies, I imagine.
4. Regardless of the prior step's results or if the action is cancelled, the VM is sized back down to an `e2-medium` to save on runtime costs. This behavior is enabled through the `if: always()` clause on the "Size down OLS machine for serving" step.

### Things to address:
- At the moment, if the workflow is triggered again while a prior run is still executing, it will interrupt the previous run. We might consider adding the "Skip Concurrent Workflows" action to address that  (see https://github.com/marketplace/actions/skip-duplicate-actions#skip-concurrent-workflow-runs to block it from re-running or https://github.com/marketplace/actions/skip-duplicate-actions#cancel-outdated-workflow-runs to cancel the prior run)
- Longer-term improvement ideas, observations:
  - We should probably figure out what build artifacts the `redeploy.sh` script is producing and build them elsewhere, i.e. on a Jenkins server or a building container if we move to Kubernetes. We could then deploy the resulting artifacts to the serving VM and restart it, which should theoretically be quick. That'd also avoid having to resize the serving VM, since it won't have to be large enough to run the build process anymore.
