### PR TITLE
Add OMIM to OLS config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ URIBASE = http://purl.obolibrary.org/obo
 ROBOT=robot
 # the below onts were collected from ols-config.yaml
 # (note that .owl is appended to each of these later on, so there's no need to add it here)
-ONTS = upheno2 upheno-patterns vbo-edit hp-edit chr mondo-edit mondo-rare mondo-patterns hp-branch-lymphoma
+ONTS = upheno2 upheno-patterns vbo-edit hp-edit chr mondo-edit mondo-rare mondo-patterns hp-branch-lymphoma omim
 
 #monarch
 ONTFILES = $(foreach n, $(ONTS), ontologies/$(n).owl)
@@ -49,6 +49,9 @@ ontologies/vbo-edit.owl:
 
 ontologies/chr.owl: 
 	$(ROBOT) convert -I https://raw.githubusercontent.com/monarch-initiative/monochrom/master/chr.owl -o $@.tmp.owl && mv $@.tmp.owl $@
+
+ontologies/omim.owl: 
+	$(ROBOT) convert -I https://github.com/monarch-initiative/omim/releases/latest/download/omim.owl -o $@.tmp.owl && mv $@.tmp.owl $@
 
 UPHENO_URL=https://github.com/obophenotype/upheno-dev/releases/download/v2023-10-27/upheno_all.owl
 

--- a/config/ols-config/ols-config.yaml
+++ b/config/ols-config/ols-config.yaml
@@ -125,6 +125,25 @@ ontologies:
     reasoner: EL
     oboSlims: false
     ontology_purl : file:/mnt/ontologies/mondo-edit.owl
+  - id: omim
+    preferredPrefix: OMIM
+    title: Monarch version of OMIM (Development Snapshot for ETL)
+    uri: https://github.com/monarch-initiative/omim/releases/latest/download/omim.owl
+    description: >
+      Unofficial development snapshot of the Monarch version OMIM, see https://github.com/monarch-initiative/omim.
+      The file is not meant to be used by anything other than Mondo ETL, and serves merely as a 
+      flat, browsable representation of the OMIM diseases as a reference for Mondo curators.
+    base_uri:
+      - https://omim.org/phenotypicSeries/PS
+      - https://omim.org/entry/
+    synonym_property:
+      - http://www.geneontology.org/formats/oboInOwl#hasExactSynonym
+    definition_property:
+      - http://purl.obolibrary.org/obo/IAO_0000115
+#    label_property:  http://www.w3.org/2004/02/skos/core#prefLabel
+    reasoner: EL
+    oboSlims: false
+    ontology_purl : file:/mnt/ontologies/omim.owl
   - id: chr
     preferredPrefix: CHR
     title: Monochrom Ontology (Development Snapshot)


### PR DESCRIPTION
To make it easier in meetings like the Monarch Data call and the Mondo technical call to check "what we have in the OMIM ingest" I am adding the OMIM ingest here to the Monarch OLS. This way, curators can quickly see which "gene-to-disease" relationships there are, and what evidence there is.