### PR TITLE
Add ClinGen Subset to OLS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ URIBASE = http://purl.obolibrary.org/obo
 ROBOT=robot
 # the below onts were collected from ols-config.yaml
 # (note that .owl is appended to each of these later on, so there's no need to add it here)
-ONTS = upheno2 upheno-patterns vbo-edit hp-edit chr mondo-edit mondo-rare mondo-patterns hp-branch-lymphoma omim
+ONTS = upheno2 upheno-patterns vbo-edit hp-edit chr mondo-edit mondo-rare mondo-patterns hp-branch-lymphoma omim mondo-clingen
 
 #monarch
 ONTFILES = $(foreach n, $(ONTS), ontologies/$(n).owl)
@@ -68,6 +68,9 @@ ontologies/mondo-patterns.owl:
 
 ontologies/mondo-rare.owl:
 	$(ROBOT) convert -I http://purl.obolibrary.org/obo/mondo/subsets/mondo-rare.owl -o $@.tmp.owl && mv $@.tmp.owl $@
+
+ontologies/mondo-clingen.owl:
+	$(ROBOT) convert -I https://raw.githubusercontent.com/monarch-initiative/mondo/gard-import/src/ontology/subsets/mondo-clingen.owl -o $@.tmp.owl && mv $@.tmp.owl $@
 
 ontologies/uberon-human-view.owl:
 	$(ROBOT) convert -I http://purl.obolibrary.org/obo/uberon/subsets/human-view.owl -o $@.tmp.owl && mv $@.tmp.owl $@

--- a/config/ols-config/ols-config.yaml
+++ b/config/ols-config/ols-config.yaml
@@ -110,6 +110,23 @@ ontologies:
     reasoner: EL
     oboSlims: false
     ontology_purl : file:/mnt/ontologies/mondo-rare.owl
+  - id: mondo_clingen
+    preferredPrefix: MONDO_CLINGEN
+    title: Mondo Disease Ontology (ClinGen Subset)
+    uri: http://purl.obolibrary.org/obo/mondo/subsets/mondo-clingen.owl
+    description: >
+      Development Snapshot of the Mondo ClinGen Subset. DO NOT USE IN PRODUCTION.
+      The Mondo ClinGen subset contains all the diseases that are in the ClinGen database
+      and displays the labels preferred by ClinGen.
+    base_uri:
+      - http://purl.obolibrary.org/obo/MONDO_
+    synonym_property:
+      - http://www.geneontology.org/formats/oboInOwl#hasExactSynonym
+    definition_property:
+      - http://purl.obolibrary.org/obo/IAO_0000115
+    reasoner: EL
+    oboSlims: false
+    ontology_purl : file:/mnt/ontologies/mondo-clingen.owl
   - id: mondo
     preferredPrefix: MONDO_DEV
     title: Mondo Disease Ontology (Development Snapshot)


### PR DESCRIPTION
This is a first snapshot of the new ClinGen subset, for discussion.

It displays 

1. all terms in the ClinGen subset
2. their parents (and ancestors)
3. The preferred label of ClinGen
4. If a preferred label was swapped out, we add the original label as an exact synonym