### PR TITLE
Update Makefile - remove mondo-clingen-review entry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ URIBASE = http://purl.obolibrary.org/obo
 ROBOT=robot
 # the below onts were collected from ols-config.yaml
 # (note that .owl is appended to each of these later on, so there's no need to add it here)
-ONTS = upheno-reordered upheno-patterns vbo-edit chr mondo-edit mondo-rare mondo-patterns mondo-matrix omim mondo-clingen mondo-clingen-review
+ONTS = upheno-reordered upheno-patterns vbo-edit chr mondo-edit mondo-rare mondo-patterns mondo-matrix omim mondo-clingen
 
 #monarch
 ONTFILES = $(foreach n, $(ONTS), ontologies/$(n).owl)

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,14 @@ ontologies/mondo-branch-%.owl:
 	cd github/mondo-branch-$*/mondo/src/ontology/ && make IMP=false PAT=false MIR=false mondo.owl
 	cp github/mondo-branch-$*/mondo/src/ontology/mondo.owl $@
 
-ontologies/mondo-clingen-review.owl:
-	mkdir -p github/mondo-clingen-review && rm -rf github/mondo-clingen-review/*
-	cd github/mondo-clingen-review && \
-	  git clone --depth 1 https://github.com/monarch-initiative/mondo.git -b issue-9178 && \
-	  cd mondo/src/ontology && \
-	  make subsets/mondo-clingen.owl IMP=false MIR=false && \
-	  mv subsets/mondo-clingen.owl ../../../../../ontologies/mondo-clingen-review.owl
+# Stub entry for Mondo branch to use specifically to review content for ClinGen. Replace `issue-9178` with new feature branch to deploy.
+# ontologies/mondo-clingen-review.owl:
+#	mkdir -p github/mondo-clingen-review && rm -rf github/mondo-clingen-review/*
+#	cd github/mondo-clingen-review && \
+#	  git clone --depth 1 https://github.com/monarch-initiative/mondo.git -b issue-9178 && \
+#	  cd mondo/src/ontology && \
+#	  make subsets/mondo-clingen.owl IMP=false MIR=false && \
+#	  mv subsets/mondo-clingen.owl ../../../../../ontologies/mondo-clingen-review.owl
 
 ontologies/mondo-edit.owl:
 	mkdir -p github && mkdir -p github/main && rm -rf github/main/*


### PR DESCRIPTION
The current entry for mondo-clingen-review was set-up to use github branch `issue-9178`. This review work is now complete and the github branch is deleted. Sabrina said "the ols version of branch referring to issue-9178 can be deleted now." in this [Slack comment](https://monarchinitiative.slack.com/archives/G01JACCEDAB/p1755026006723549?thread_ts=1755025726.427119&cid=G01JACCEDAB).

I have commented out the entry so it can more easily be used as a stub in the future if a new mondo-clingen-review entry is added for a future github feature branch.

cc: @jamesamcl as you mentioned you have forthcoming PR 